### PR TITLE
Allow using unsafe directory in container

### DIFF
--- a/ansible-docker.sh
+++ b/ansible-docker.sh
@@ -62,6 +62,8 @@ ansible::test::playbook() {
   ansible-playbook --connection=local --inventory host.ini ${TARGETS} 
 }
 
+# avoid git complaining about directory owned by somebody else in the container
+git config --global --add safe.directory /github/workspace
 # make sure git is up to date
 git submodule update --init --recursive
 if [[ "${REQUIREMENTS}" == *.yml ]]


### PR DESCRIPTION
I am getting failures like this after updating git to recent version:
```
+ git submodule update --init --recursive
fatal: unsafe repository ('/github/workspace' is owned by someone else)
To add an exception for this directory, call:

	git config --global --add safe.directory /github/workspace
```
Same as https://github.com/roles-ansible/check-ansible-ubuntu-latest-action/pull/2/ and https://github.com/roles-ansible/check-ansible-ubuntu-focal-action/pull/2/